### PR TITLE
Integrate Supabase profiles and bookmarks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,96 +1,3 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { AuthProvider, useAuth } from './context/AuthContext';
-import { ProjectProvider } from './context/ProjectContext';
-import Login from './pages/Login';
-import Projects from './pages/Projects';
-import ProjectDetail from './pages/ProjectDetail';
-import Calendar from './pages/Calendar';
-import Team from './pages/Team';
-import Settings from './pages/Settings';
-import SetupStatus from './pages/SetupStatus';
-import NotFound from './pages/NotFound';
-import './App.css';
-
-// 보호된 라우트 컴포넌트
-const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
-  const { isAuthenticated, isLoading } = useAuth();
-  
-  if (isLoading) {
-    return <div>로딩 중...</div>;
-  }
-  
-  if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
-  }
-  
-  return <>{children}</>;
-};
-
-function App() {
-  return (
-    <AuthProvider>
-      <ProjectProvider>
-        <Router>
-          <Routes>
-            <Route path="/login" element={<Login />} />
-            <Route path="/setup" element={<SetupStatus />} />
-            <Route 
-              path="/" 
-              element={
-                <ProtectedRoute>
-                  <Navigate to="/projects" replace />
-                </ProtectedRoute>
-              } 
-            />
-            <Route 
-              path="/projects" 
-              element={
-                <ProtectedRoute>
-                  <Projects />
-                </ProtectedRoute>
-              } 
-            />
-            <Route 
-              path="/projects/:id" 
-              element={
-                <ProtectedRoute>
-                  <ProjectDetail />
-                </ProtectedRoute>
-              } 
-            />
-            <Route 
-              path="/calendar" 
-              element={
-                <ProtectedRoute>
-                  <Calendar />
-                </ProtectedRoute>
-              } 
-            />
-            <Route 
-              path="/team" 
-              element={
-                <ProtectedRoute>
-                  <Team />
-                </ProtectedRoute>
-              } 
-            />
-            <Route 
-              path="/settings" 
-              element={
-                <ProtectedRoute>
-                  <Settings />
-                </ProtectedRoute>
-              } 
-            />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </Router>
-      </ProjectProvider>
-    </AuthProvider>
-  );
-}
-
-export default App;
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -106,6 +13,7 @@ import ProjectDetail from "./pages/ProjectDetail";
 import Calendar from "./pages/Calendar";
 import Team from "./pages/Team";
 import Settings from "./pages/Settings";
+import Profile from "./pages/Profile";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -124,6 +32,7 @@ const App = () => (
                 <Route path="/projects/:projectId" element={<ProjectDetail />} />
                 <Route path="/calendar" element={<Calendar />} />
                 <Route path="/team" element={<Team />} />
+                <Route path="/profile" element={<Profile />} />
                 <Route path="/settings" element={<Settings />} />
                 <Route path="*" element={<NotFound />} />
               </Routes>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -190,9 +190,9 @@ const Header: React.FC<HeaderProps> = ({ onToggleSidebar }) => {
               aria-label="User menu"
             >
               <Avatar>
-                <AvatarImage src={user?.avatarUrl} alt={user?.name || "User"} />
+                <AvatarImage src={user?.avatar_url || ''} alt={user?.nickname || 'User'} />
                 <AvatarFallback>
-                  {user?.name ? getInitials(user.name) : "U"}
+                  {user?.nickname ? getInitials(user.nickname) : 'U'}
                 </AvatarFallback>
               </Avatar>
             </Button>
@@ -200,16 +200,18 @@ const Header: React.FC<HeaderProps> = ({ onToggleSidebar }) => {
           <DropdownMenuContent align="end" className="w-56">
             <DropdownMenuLabel>
               <div className="flex flex-col space-y-1">
-                <p className="text-sm font-medium leading-none">{user?.name}</p>
+                <p className="text-sm font-medium leading-none">{user?.nickname}</p>
                 <p className="text-xs leading-none text-muted-foreground">
                   {user?.email}
                 </p>
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <DropdownMenuItem>
-              <User className="mr-2 h-4 w-4" />
-              <span>프로필</span>
+            <DropdownMenuItem asChild>
+              <Link to="/profile" className="cursor-pointer">
+                <User className="mr-2 h-4 w-4" />
+                <span>프로필</span>
+              </Link>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={logout}>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,184 +1,70 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import { supabase } from '../lib/supabase';
-import { User } from '../lib/api/users';
+import { Profile } from '../lib/api/profiles';
 
-type AuthContextType = {
-  user: User | null;
-  token: string | null;
+interface AuthContextType {
+  user: Profile | null;
   isLoading: boolean;
   isAuthenticated: boolean;
   login: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
-  checkAuth: () => Promise<boolean>;
-};
-
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
-
-export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const [user, setUser] = useState<User | null>(null);
-  const [token, setToken] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-
-  useEffect(() => {
-    // 로컬 스토리지에서 토큰 확인
-    const storedToken = localStorage.getItem('pms_token');
-    const storedUser = localStorage.getItem('pms_user');
-    
-    if (storedToken && storedUser) {
-      setToken(storedToken);
-      setUser(JSON.parse(storedUser));
-      setIsAuthenticated(true);
-    }
-    
-    setIsLoading(false);
-  }, []);
-
-  // 로그인 함수
-  const login = async (email: string, password: string) => {
-    setIsLoading(true);
-    
-    try {
-      // Supabase에서 사용자 조회
-      const { data, error } = await supabase
-        .from('users')
-        .select('*')
-        .eq('email', email)
-        .single();
-      
-      if (error || !data) {
-        throw new Error('로그인 실패: 사용자를 찾을 수 없습니다.');
-      }
-      
-      // 실제 애플리케이션에서는 비밀번호 해싱 및 비교 로직이 필요함
-      // 여기서는 간단한 예시로 직접 비교
-      if (data.password !== password) {
-        throw new Error('로그인 실패: 비밀번호가 일치하지 않습니다.');
-      }
-      
-      // JWT 토큰 생성 (실제로는 서버에서 생성해야 함)
-      // 이 예시에서는 임시로 간단한 토큰 생성
-      const mockToken = btoa(`${data.id}:${data.email}:${Date.now()}`);
-      
-      // 사용자 정보 및 토큰 저장
-      setUser(data);
-      setToken(mockToken);
-      setIsAuthenticated(true);
-      
-      // 로컬 스토리지에 저장
-      localStorage.setItem('pms_token', mockToken);
-      localStorage.setItem('pms_user', JSON.stringify(data));
-    } catch (error) {
-      console.error('로그인 오류:', error);
-      throw error;
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // 로그아웃 함수
-  const logout = async () => {
-    setIsLoading(true);
-    
-    try {
-      // 상태 초기화
-      setUser(null);
-      setToken(null);
-      setIsAuthenticated(false);
-      
-      // 로컬 스토리지에서 제거
-      localStorage.removeItem('pms_token');
-      localStorage.removeItem('pms_user');
-    } catch (error) {
-      console.error('로그아웃 오류:', error);
-      throw error;
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // 인증 상태 확인
-  const checkAuth = async () => {
-    if (token && user) {
-      return true;
-    }
-    return false;
-  };
-
-  const value = {
-    user,
-    token,
-    isLoading,
-    isAuthenticated,
-    login,
-    logout,
-    checkAuth,
-  };
-
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
-};
-
-export const useAuth = () => {
-  const context = useContext(AuthContext);
-  if (context === undefined) {
-    throw new Error('useAuth는 AuthProvider 내부에서만 사용할 수 있습니다.');
-  }
-  return context;
-};
-import React, { createContext, useContext, useState, useEffect } from 'react';
-import { User } from '../types';
-import { currentUser } from '../data/mockData';
-import { toast } from "sonner";
-
-interface AuthContextType {
-  user: User | null;
-  login: (email: string, password: string) => Promise<void>;
-  logout: () => void;
-  isAuthenticated: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [user, setUser] = useState<User | null>(null);
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<Profile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  // Check if user is already logged in
   useEffect(() => {
-    const storedUser = localStorage.getItem('pms-user');
-    if (storedUser) {
-      setUser(JSON.parse(storedUser));
-      setIsAuthenticated(true);
-    }
+    const init = async () => {
+      const { data } = await supabase.auth.getSession();
+      if (data.session) {
+        const { user } = data.session;
+        const { data: profile } = await supabase
+          .from('profiles')
+          .select('*')
+          .eq('id', user.id)
+          .single();
+        if (profile) {
+          setUser(profile);
+          setIsAuthenticated(true);
+        }
+      }
+      setIsLoading(false);
+    };
+    init();
   }, []);
 
   const login = async (email: string, password: string) => {
-    try {
-      // In a real app, this would be an API call
-      // For now, we'll just use our mock data
-      if (email === currentUser.email && password === 'password') {
-        setUser(currentUser);
-        setIsAuthenticated(true);
-        localStorage.setItem('pms-user', JSON.stringify(currentUser));
-        toast.success("로그인 되었습니다.");
-      } else {
-        throw new Error('Invalid credentials');
-      }
-    } catch (error) {
-      toast.error("이메일 또는 비밀번호가 잘못되었습니다.");
-      throw error;
+    setIsLoading(true);
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error || !data.session) {
+      setIsLoading(false);
+      throw error || new Error('login failed');
     }
+    const { user } = data.session;
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single();
+    setUser(profile || null);
+    setIsAuthenticated(true);
+    setIsLoading(false);
   };
 
-  const logout = () => {
+  const logout = async () => {
+    setIsLoading(true);
+    await supabase.auth.signOut();
     setUser(null);
     setIsAuthenticated(false);
-    localStorage.removeItem('pms-user');
-    toast.info("로그아웃 되었습니다.");
+    setIsLoading(false);
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, logout, isAuthenticated }}>
+    <AuthContext.Provider value={{ user, isLoading, isAuthenticated, login, logout }}>
       {children}
     </AuthContext.Provider>
   );
@@ -186,8 +72,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
 export const useAuth = () => {
   const context = useContext(AuthContext);
-  if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider');
-  }
+  if (!context) throw new Error('useAuth must be used within AuthProvider');
   return context;
 };

--- a/src/lib/api/bookmarks.ts
+++ b/src/lib/api/bookmarks.ts
@@ -1,0 +1,46 @@
+import { supabase } from '../supabase';
+import { Tables, Insertable, Updateable } from '../../types/supabase';
+
+export type Bookmark = Tables<'bookmarks'>;
+export type NewBookmark = Insertable<'bookmarks'>;
+export type UpdateBookmark = Updateable<'bookmarks'>;
+
+export const createBookmark = async (bookmark: NewBookmark) => {
+  const { data, error } = await supabase
+    .from('bookmarks')
+    .insert(bookmark)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+};
+
+export const getBookmarksByUser = async (userId: string) => {
+  const { data, error } = await supabase
+    .from('bookmarks')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+  return data;
+};
+
+export const updateBookmark = async (id: string, bookmark: UpdateBookmark) => {
+  const { data, error } = await supabase
+    .from('bookmarks')
+    .update(bookmark)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+};
+
+export const deleteBookmark = async (id: string) => {
+  const { error } = await supabase.from('bookmarks').delete().eq('id', id);
+  if (error) throw error;
+  return true;
+};

--- a/src/lib/api/profiles.ts
+++ b/src/lib/api/profiles.ts
@@ -1,0 +1,28 @@
+import { supabase } from '../supabase';
+import { Tables, Insertable, Updateable } from '../../types/supabase';
+
+export type Profile = Tables<'profiles'>;
+export type NewProfile = Insertable<'profiles'>;
+export type UpdateProfile = Updateable<'profiles'>;
+
+export const getProfile = async (id: string) => {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) throw error;
+  return data;
+};
+
+export const upsertProfile = async (profile: NewProfile | UpdateProfile) => {
+  const { data, error } = await supabase
+    .from('profiles')
+    .upsert(profile)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+};

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import { upsertProfile } from '@/lib/api/profiles';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const ProfilePage = () => {
+  const { user, isAuthenticated } = useAuth();
+  const [nickname, setNickname] = useState('');
+  const [avatarUrl, setAvatarUrl] = useState('');
+
+  useEffect(() => {
+    if (user) {
+      setNickname(user.nickname || '');
+      setAvatarUrl(user.avatar_url || '');
+    }
+  }, [user]);
+
+  if (!isAuthenticated || !user) return null;
+
+  const handleSave = async () => {
+    await upsertProfile({ id: user.id, nickname, avatar_url: avatarUrl });
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>프로필 수정</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <label className="block mb-1">닉네임</label>
+            <Input value={nickname} onChange={(e) => setNickname(e.target.value)} />
+          </div>
+          <div>
+            <label className="block mb-1">아바타 URL</label>
+            <Input value={avatarUrl} onChange={(e) => setAvatarUrl(e.target.value)} />
+          </div>
+          <Button onClick={handleSave}>저장</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -116,6 +116,110 @@ export interface Database {
           created_at?: string
         }
       }
+      bookmarks: {
+        Row: {
+          id: string
+          user_id: string
+          url: string
+          title: string
+          description: string | null
+          image_url: string | null
+          created_at: string
+          updated_at: string
+          tags: string[] | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          url: string
+          title: string
+          description?: string | null
+          image_url?: string | null
+          created_at?: string
+          updated_at?: string
+          tags?: string[] | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          url?: string
+          title?: string
+          description?: string | null
+          image_url?: string | null
+          created_at?: string
+          updated_at?: string
+          tags?: string[] | null
+        }
+      }
+      collections: {
+        Row: {
+          id: string
+          user_id: string
+          name: string
+          description: string | null
+          cover_image: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          name: string
+          description?: string | null
+          cover_image?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          name?: string
+          description?: string | null
+          cover_image?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      collection_bookmarks: {
+        Row: {
+          collection_id: string
+          bookmark_id: string
+          created_at: string
+        }
+        Insert: {
+          collection_id: string
+          bookmark_id: string
+          created_at?: string
+        }
+        Update: {
+          collection_id?: string
+          bookmark_id?: string
+          created_at?: string
+        }
+      }
+      profiles: {
+        Row: {
+          id: string
+          nickname: string | null
+          avatar_url: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id: string
+          nickname?: string | null
+          avatar_url?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          nickname?: string | null
+          avatar_url?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add types for bookmarks, collections and profiles tables
- add Supabase bookmark and profile API helpers
- replace duplicated auth context with Supabase-based version
- link profile page from header dropdown
- provide profile editing page
- add `/profile` route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840256eb61c832aa953ae3914f4590e