### PR TITLE
Implement profile persistence

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -8,6 +8,7 @@ interface AuthContextType {
   isAuthenticated: boolean;
   login: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
+  updateProfile: (profile: Partial<Profile>) => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -63,8 +64,12 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     setIsLoading(false);
   };
 
+  const updateProfile = (profile: Partial<Profile>) => {
+    setUser(prev => (prev ? { ...prev, ...profile } : prev));
+  };
+
   return (
-    <AuthContext.Provider value={{ user, isLoading, isAuthenticated, login, logout }}>
+    <AuthContext.Provider value={{ user, isLoading, isAuthenticated, login, logout, updateProfile }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { upsertProfile } from '@/lib/api/profiles';
+import { toast } from 'sonner';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 const ProfilePage = () => {
-  const { user, isAuthenticated } = useAuth();
+  const { user, isAuthenticated, updateProfile } = useAuth();
   const [nickname, setNickname] = useState('');
   const [avatarUrl, setAvatarUrl] = useState('');
 
@@ -20,7 +21,17 @@ const ProfilePage = () => {
   if (!isAuthenticated || !user) return null;
 
   const handleSave = async () => {
-    await upsertProfile({ id: user.id, nickname, avatar_url: avatarUrl });
+    try {
+      const updated = await upsertProfile({
+        id: user.id,
+        nickname,
+        avatar_url: avatarUrl,
+      });
+      updateProfile(updated);
+      toast.success('프로필이 저장되었습니다.');
+    } catch (error) {
+      toast.error('프로필 저장에 실패했습니다.');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- update AuthContext with `updateProfile` helper
- save profile changes in `/profile` and update context

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402cc730c8832a911684a89b9f6cb9